### PR TITLE
Permissive command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,18 @@ Primitive support is provided for parsing into range of different top-level opti
 sealed case-class family
 ```scala
 sealed trait Command
-case class First(param: Long) extends Command
-case class Second(somePath: String) extends Command
+case class FirstThing(param: Long) extends Command
+case class SecondThing(somePath: String) extends Command
 ```
 `Cli.parse[Command]` will accept arguments of either form, with the case class name as the first arg
 ```
-$ run_my_app First --param 19482
-$ run_my_app Second --some-path /path/to/a/thing
+$ run_my_app first_thing --param 19482
+$ run_my_app second_thing --some-path /path/to/a/thing
 ```
+
+The matching is loose enough to understand `FirstThing` as `first_thing` or `first-thing` or `firsthing` or `FIRSTTHING`
+(case insensitive on alphanumeric reduction)
+
 If you add something like a `run()` method to the `Command` trait, you can execute it directly on the returned `Command`
 object, or else you can pattern-match against the result.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ object ExampleCli {
 Default values in your case class work in the way you'd expect. They are not required to be specified, but if they do
 they will override the value specified as the default.
 
+### Descriptive hints for usage text (0.2.0+)
+If you need extra help text for an option to go in its usage text, just annotate that field with `@Hint("helpful text")`
+
 ### Multiple "commands" via sealed case class families
 
 Primitive support is provided for parsing into range of different top-level options via representing those options as a

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>io.github.davw</groupId>
     <artifactId>no-nonsense-options</artifactId>
     <name>no-nonsense-options</name>
-    <version>0.1.2</version>
+    <version>0.2.0-SNAPSHOT</version>
     <url>https://github.com/DavW/no-nonsense-options</url>
     <description>Scala command line option parser using interfaces derived from destination types</description>
     <properties>

--- a/src/main/scala/io/github/davw/options/ArgParser.scala
+++ b/src/main/scala/io/github/davw/options/ArgParser.scala
@@ -100,13 +100,16 @@ trait DervivedArgParsers {
    tail: DiscriminatedParser[CR])        // If it's not a match, we defer to the Coproduct tail
   : DiscriminatedParser[FieldType[KL, VL] :+: CR] = new DiscriminatedParser[FieldType[KL, VL] :+: CR] {
     override def parser(command: String): Option[ArgParser[FieldType[KL, VL] :+: CR]] = {
-      if (command == keyWitness.value.name)
+      if (commandNameMatches(command, keyWitness.value.name))
         Some(transform(argParser, (x: VL) => Inl[FieldType[KL, VL], CR](field[KL](x))))
       else
         tail.parser(command).map(parser => transform(parser, (x: CR) => Inr[FieldType[KL, VL], CR](x)))
     }
     override def options: Seq[String] = Seq(keyWitness.value.name) ++ tail.options
   }
+
+  def commandNameMatches(commandName: String, className: String): Boolean =
+    commandName.toLowerCase.replaceAll("[^A-Za-z0-9]", "") == className.toLowerCase.replaceAll("[^A-Za-z0-9]", "")
 
   /** Using the DiscriminatedParser implementation that can be derived from the isomorphic Coproduct to a sealed case
    *  class family, we can simply define an ArgParser implementation for the case class family, by taking the first

--- a/src/test/scala/io/github/davw/options/CliSpec.scala
+++ b/src/test/scala/io/github/davw/options/CliSpec.scala
@@ -71,6 +71,11 @@ class CliSpec extends FlatSpec {
     assert(Cli.parseOrThrow[Commands](Seq("CommandTwo", "--input", "my_input", "--throughput", "my_throughput")) == CommandTwo("my_input", "my_throughput"))
   }
 
+  it should "be parsed with loosely-matching first arguments in common forms" in {
+    assert(Cli.parseOrThrow[Commands](Seq("command_one", "--input", "my_input", "--output", "my_output", "--mode", "mode_one")) == CommandOne("my_input", "my_output", "mode_one"))
+    assert(Cli.parseOrThrow[Commands](Seq("COMMANDTWO", "--input", "my_input", "--throughput", "my_throughput")) == CommandTwo("my_input", "my_throughput"))
+  }
+
   case class CommandWithDefaults(input: String, output: String = "/dev/null")
 
   "A case class with a default value" should "be parsed with or without the argument with a default value being passed" in {


### PR DESCRIPTION
This patch allows more permissive command names than exact matches on class name. Pragmatically, this means that real world usage will be more intuitive, but from a purist point of view it adds more theoretical error cases (even if they're unlikely).

Alternatives are (1) leaving exact matching in place or (2) enforce a convention like `snake_case` for command names